### PR TITLE
configurable max_payload_size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sctp-proto"
-version = "0.1.1"
+version = "0.1.3"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
 edition = "2021"
 description = "State machine for the SCTP protocol"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/sctp-proto"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/sctp"
+repository = "https://github.com/webrtc-rs/sctp-proto"
 keywords = ["sctp"]
 categories = [ "network-programming", "asynchronous" ]
 

--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -6,6 +6,7 @@ fn create_association(config: TransportConfig) -> Association {
     Association::new(
         None,
         Arc::new(config),
+        1400,
         0,
         SocketAddr::from_str("0.0.0.0:0").unwrap(),
         None,

--- a/src/endpoint/endpoint_test.rs
+++ b/src/endpoint/endpoint_test.rs
@@ -2193,7 +2193,7 @@ fn test_association_handle_packet_before_init() -> Result<()> {
 
         //let (a_conn, charlie_conn) = pipe();
         let config = Arc::new(TransportConfig::default());
-        let mut a = Association::new(None, config, 0, remote, None, Instant::now());
+        let mut a = Association::new(None, config, 1400, 0, remote, None, Instant::now());
 
         let packet = packet.marshal()?;
         a.handle_event(AssociationEvent(AssociationEventInner::Datagram(

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -281,6 +281,7 @@ impl Endpoint {
         let conn = Association::new(
             server_config,
             transport_config,
+            self.config.get_max_payload_size(),
             local_aid,
             remote_addr,
             local_ip,


### PR DESCRIPTION
The `AssociationConfig` has a field `max_payload_config`. However in `Association` rather than using this field, a new default value is calculated. This PR makes it so the configuration goes all the way to `StreamState`.