### PR TITLE
Clippys and rust analyzer warnings.

### DIFF
--- a/src/association/association_test.rs
+++ b/src/association/association_test.rs
@@ -16,10 +16,12 @@ fn create_association(config: TransportConfig) -> Association {
 
 #[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        cumulative_tsn_ack_point: 9,
+        advanced_peer_tsn_ack_point: 10,
+        ..Default::default()
+    };
 
-    a.cumulative_tsn_ack_point = 9;
-    a.advanced_peer_tsn_ack_point = 10;
     a.inflight_queue.push_no_check(ChunkPayloadData {
         beginning_fragment: true,
         ending_fragment: true,
@@ -44,10 +46,12 @@ fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
 
 #[test]
 fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        cumulative_tsn_ack_point: 9,
+        advanced_peer_tsn_ack_point: 12,
+        ..Default::default()
+    };
 
-    a.cumulative_tsn_ack_point = 9;
-    a.advanced_peer_tsn_ack_point = 12;
     a.inflight_queue.push_no_check(ChunkPayloadData {
         beginning_fragment: true,
         ending_fragment: true,
@@ -99,7 +103,7 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
                 assert_eq!(1, s.sequence, "ssn should be 1");
                 si2ok = true;
             }
-            _ => assert!(false, "unexpected stream indentifier"),
+            _ => panic!("unexpected stream indentifier"),
         }
     }
     assert!(si1ok, "si=1 should be present");
@@ -110,9 +114,11 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
 
 #[test]
 fn test_handle_forward_tsn_forward_3unreceived_chunks() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
 
-    a.use_forward_tsn = true;
     let prev_tsn = a.peer_last_tsn;
 
     let fwdtsn = ChunkForwardTsn {
@@ -144,9 +150,11 @@ fn test_handle_forward_tsn_forward_3unreceived_chunks() -> Result<()> {
 
 #[test]
 fn test_handle_forward_tsn_forward_1for1_missing() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
 
-    a.use_forward_tsn = true;
     let prev_tsn = a.peer_last_tsn;
 
     // this chunk is blocked by the missing chunk at tsn=1
@@ -192,7 +200,10 @@ fn test_handle_forward_tsn_forward_1for1_missing() -> Result<()> {
 
 #[test]
 fn test_handle_forward_tsn_forward_1for2_missing() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
 
     a.use_forward_tsn = true;
     let prev_tsn = a.peer_last_tsn;
@@ -238,9 +249,11 @@ fn test_handle_forward_tsn_forward_1for2_missing() -> Result<()> {
 
 #[test]
 fn test_handle_forward_tsn_dup_forward_tsn_chunk_should_generate_sack() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        use_forward_tsn: true,
+        ..Default::default()
+    };
 
-    a.use_forward_tsn = true;
     let prev_tsn = a.peer_last_tsn;
 
     let fwdtsn = ChunkForwardTsn {
@@ -270,8 +283,7 @@ fn test_assoc_create_new_stream() -> Result<()> {
             if let Some(s) = a.create_stream(i as u16, true, PayloadProtocolIdentifier::Unknown) {
                 s.stream_identifier
             } else {
-                assert!(false, "{} should success", i);
-                0
+                panic!("{} should success", i);
             };
         let result = a.streams.get(&stream_identifier);
         assert!(result.is_some(), "should be in a.streams map");
@@ -406,7 +418,7 @@ fn test_assoc_max_message_size_default() -> Result<()> {
                 "should be not Error::ErrOutboundPacketTooLarge"
             );
         } else {
-            assert!(false, "should be error");
+            panic!("should be error");
         }
 
         if let Err(err) = s.write_sctp(&p.slice(..65537), ppi) {
@@ -416,7 +428,7 @@ fn test_assoc_max_message_size_default() -> Result<()> {
                 "should be Error::ErrOutboundPacketTooLarge"
             );
         } else {
-            assert!(false, "should be error");
+            panic!("should be error");
         }
     }
 
@@ -443,7 +455,7 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
                 "should be not Error::ErrOutboundPacketTooLarge"
             );
         } else {
-            assert!(false, "should be error");
+            panic!("should be error");
         }
 
         if let Err(err) = s.write_sctp(&p.slice(..30001), ppi) {
@@ -453,7 +465,7 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
                 "should be Error::ErrOutboundPacketTooLarge"
             );
         } else {
-            assert!(false, "should be error");
+            panic!("should be error");
         }
     }
 

--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -1889,7 +1889,6 @@ impl Association {
                     reconfig_response_sequence_number: p.reconfig_request_sequence_number,
                     sender_last_tsn: tsn,
                     stream_identifiers: sis_to_reset,
-                    ..Default::default()
                 })),
                 ..Default::default()
             };

--- a/src/association/state.rs
+++ b/src/association/state.rs
@@ -2,7 +2,9 @@ use std::fmt;
 
 /// association state enums
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Default)]
 pub(crate) enum AssociationState {
+    #[default]
     Closed = 0,
     CookieWait = 1,
     CookieEchoed = 2,
@@ -13,11 +15,7 @@ pub(crate) enum AssociationState {
     ShutdownSent = 7,
 }
 
-impl Default for AssociationState {
-    fn default() -> Self {
-        AssociationState::Closed
-    }
-}
+
 
 impl From<u8> for AssociationState {
     fn from(v: u8) -> AssociationState {
@@ -64,16 +62,14 @@ impl AssociationState {
 
 /// ack mode (for testing)
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Default)]
 pub(crate) enum AckMode {
+    #[default]
     Normal,
     NoDelay,
     AlwaysDelay,
 }
-impl Default for AckMode {
-    fn default() -> Self {
-        AckMode::Normal
-    }
-}
+
 
 impl fmt::Display for AckMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -88,17 +84,15 @@ impl fmt::Display for AckMode {
 
 /// ack transmission state
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Default)]
 pub(crate) enum AckState {
+    #[default]
     Idle,      // ack timer is off
     Immediate, // will send ack immediately
     Delay,     // ack timer is on (ack is being delayed)
 }
 
-impl Default for AckState {
-    fn default() -> Self {
-        AckState::Idle
-    }
-}
+
 
 impl fmt::Display for AckState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/association/state.rs
+++ b/src/association/state.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 
 /// association state enums
-#[derive(Debug, Copy, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub(crate) enum AssociationState {
     #[default]
     Closed = 0,
@@ -14,8 +13,6 @@ pub(crate) enum AssociationState {
     ShutdownReceived = 6,
     ShutdownSent = 7,
 }
-
-
 
 impl From<u8> for AssociationState {
     fn from(v: u8) -> AssociationState {
@@ -61,15 +58,13 @@ impl AssociationState {
 }
 
 /// ack mode (for testing)
-#[derive(Debug, Copy, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub(crate) enum AckMode {
     #[default]
     Normal,
     NoDelay,
     AlwaysDelay,
 }
-
 
 impl fmt::Display for AckMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -83,16 +78,13 @@ impl fmt::Display for AckMode {
 }
 
 /// ack transmission state
-#[derive(Debug, Copy, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub(crate) enum AckState {
     #[default]
-    Idle,      // ack timer is off
+    Idle, // ack timer is off
     Immediate, // will send ack immediately
     Delay,     // ack timer is on (ack is being delayed)
 }
-
-
 
 impl fmt::Display for AckState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -52,8 +52,7 @@ pub enum StreamEvent {
 }
 
 /// Reliability type for stream
-#[derive(Debug, Copy, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub enum ReliabilityType {
     /// ReliabilityTypeReliable is used for reliable transmission
     #[default]
@@ -63,8 +62,6 @@ pub enum ReliabilityType {
     /// ReliabilityTypeTimed is used for partial reliability by retransmission duration
     Timed = 2,
 }
-
-
 
 impl fmt::Display for ReliabilityType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -317,8 +314,7 @@ impl<'a> Stream<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum RecvSendState {
     #[default]
     Closed = 0,
@@ -337,8 +333,6 @@ impl From<u8> for RecvSendState {
         }
     }
 }
-
-
 
 /// StreamState represents the state of an SCTP stream
 #[derive(Default, Debug)]

--- a/src/association/stream.rs
+++ b/src/association/stream.rs
@@ -53,8 +53,10 @@ pub enum StreamEvent {
 
 /// Reliability type for stream
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Default)]
 pub enum ReliabilityType {
     /// ReliabilityTypeReliable is used for reliable transmission
+    #[default]
     Reliable = 0,
     /// ReliabilityTypeRexmit is used for partial reliability by retransmission count
     Rexmit = 1,
@@ -62,11 +64,7 @@ pub enum ReliabilityType {
     Timed = 2,
 }
 
-impl Default for ReliabilityType {
-    fn default() -> Self {
-        ReliabilityType::Reliable
-    }
-}
+
 
 impl fmt::Display for ReliabilityType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -320,7 +318,9 @@ impl<'a> Stream<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default)]
 pub enum RecvSendState {
+    #[default]
     Closed = 0,
     Readable = 1,
     Writable = 2,
@@ -338,11 +338,7 @@ impl From<u8> for RecvSendState {
     }
 }
 
-impl Default for RecvSendState {
-    fn default() -> Self {
-        RecvSendState::Closed
-    }
-}
+
 
 /// StreamState represents the state of an SCTP stream
 #[derive(Default, Debug)]

--- a/src/chunk/chunk_abort.rs
+++ b/src/chunk/chunk_abort.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///Abort represents an SCTP Chunk of type ABORT
 ///
 ///The ABORT chunk is sent to the peer of an association to close the

--- a/src/chunk/chunk_cookie_ack.rs
+++ b/src/chunk/chunk_cookie_ack.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 /// chunkCookieAck represents an SCTP Chunk of type chunkCookieAck
 ///
 ///  0                   1                   2                   3

--- a/src/chunk/chunk_cookie_echo.rs
+++ b/src/chunk/chunk_cookie_echo.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 /// CookieEcho represents an SCTP Chunk of type CookieEcho
 ///
 ///  0                   1                   2                   3

--- a/src/chunk/chunk_error.rs
+++ b/src/chunk/chunk_error.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///Operation Error (ERROR) (9)
 ///
 ///An endpoint sends this chunk to its peer endpoint to notify it of

--- a/src/chunk/chunk_forward_tsn.rs
+++ b/src/chunk/chunk_forward_tsn.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
-
 ///This chunk shall be used by the data sender to inform the data
 ///receiver to adjust its cumulative received TSN point forward because
 ///some missing TSNs are associated with data chunks that SHOULD NOT be

--- a/src/chunk/chunk_header.rs
+++ b/src/chunk/chunk_header.rs
@@ -1,8 +1,5 @@
 use super::{chunk_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
-
 ///chunkHeader represents a SCTP Chunk header, defined in https://tools.ietf.org/html/rfc4960#section-3.2
 ///The figure below illustrates the field format for the chunks to be
 ///transmitted in the SCTP packet.  Each chunk is formatted with a Chunk

--- a/src/chunk/chunk_heartbeat.rs
+++ b/src/chunk/chunk_heartbeat.rs
@@ -1,9 +1,6 @@
 use super::{chunk_header::*, chunk_type::*, *};
 use crate::param::{param_header::*, param_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///chunkHeartbeat represents an SCTP Chunk of type HEARTBEAT
 ///
 ///An endpoint should send this chunk to its peer endpoint to probe the

--- a/src/chunk/chunk_heartbeat_ack.rs
+++ b/src/chunk/chunk_heartbeat_ack.rs
@@ -3,9 +3,6 @@ use crate::param::param_type::ParamType;
 use crate::param::{param_header::*, *};
 use crate::util::get_padding_size;
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///chunkHeartbeatAck represents an SCTP Chunk of type HEARTBEAT ACK
 ///
 ///An endpoint should send this chunk to its peer endpoint as a response

--- a/src/chunk/chunk_init.rs
+++ b/src/chunk/chunk_init.rs
@@ -3,9 +3,6 @@ use crate::param::param_supported_extensions::ParamSupportedExtensions;
 use crate::param::{param_header::*, *};
 use crate::util::get_padding_size;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
-
 ///chunkInitCommon represents an SCTP Chunk body of type INIT and INIT ACK
 ///
 /// 0                   1                   2                   3

--- a/src/chunk/chunk_payload_data.rs
+++ b/src/chunk/chunk_payload_data.rs
@@ -1,7 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
 use std::time::Instant;
 
 pub(crate) const PAYLOAD_DATA_ENDING_FRAGMENT_BITMASK: u8 = 1;
@@ -25,8 +23,6 @@ pub enum PayloadProtocolIdentifier {
     #[default]
     Unknown,
 }
-
-
 
 impl fmt::Display for PayloadProtocolIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/chunk/chunk_payload_data.rs
+++ b/src/chunk/chunk_payload_data.rs
@@ -15,20 +15,18 @@ pub(crate) const PAYLOAD_DATA_HEADER_SIZE: usize = 12;
 // <https://www.iana.org/assignments/sctp-parameters/sctp-parameters.xhtml#sctp-parameters-25>
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
+#[derive(Default)]
 pub enum PayloadProtocolIdentifier {
     Dcep = 50,
     String = 51,
     Binary = 53,
     StringEmpty = 56,
     BinaryEmpty = 57,
+    #[default]
     Unknown,
 }
 
-impl Default for PayloadProtocolIdentifier {
-    fn default() -> Self {
-        PayloadProtocolIdentifier::Unknown
-    }
-}
+
 
 impl fmt::Display for PayloadProtocolIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/chunk/chunk_reconfig.rs
+++ b/src/chunk/chunk_reconfig.rs
@@ -2,9 +2,6 @@ use super::{chunk_header::*, chunk_type::*, *};
 use crate::param::{param_header::*, *};
 use crate::util::get_padding_size;
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///https://tools.ietf.org/html/rfc6525#section-3.1
 ///chunkReconfig represents an SCTP Chunk used to reconfigure streams.
 ///

--- a/src/chunk/chunk_selective_ack.rs
+++ b/src/chunk/chunk_selective_ack.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
-
 ///chunkSelectiveAck represents an SCTP Chunk of type SACK
 ///
 ///This chunk is sent to the peer endpoint to acknowledge received DATA

--- a/src/chunk/chunk_shutdown.rs
+++ b/src/chunk/chunk_shutdown.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
-
 ///chunkShutdown represents an SCTP Chunk of type chunkShutdown
 ///
 ///0                   1                   2                   3

--- a/src/chunk/chunk_shutdown_ack.rs
+++ b/src/chunk/chunk_shutdown_ack.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///chunkShutdownAck represents an SCTP Chunk of type chunkShutdownAck
 ///
 ///0                   1                   2                   3

--- a/src/chunk/chunk_shutdown_complete.rs
+++ b/src/chunk/chunk_shutdown_complete.rs
@@ -1,8 +1,5 @@
 use super::{chunk_header::*, chunk_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-use std::fmt;
-
 ///chunkShutdownComplete represents an SCTP Chunk of type chunkShutdownComplete
 ///
 ///0                   1                   2                   3

--- a/src/chunk/chunk_test.rs
+++ b/src/chunk/chunk_test.rs
@@ -500,7 +500,7 @@ fn test_init_chunk() -> Result<()> {
             3899461680u32, c.initial_tsn
         );
     } else {
-        assert!(false, "Failed to cast Chunk -> Init");
+        panic!("Failed to cast Chunk -> Init");
     }
 
     Ok(())
@@ -627,7 +627,7 @@ fn test_init_marshal_unmarshal() -> Result<()> {
             123, c.initial_tsn
         );
     } else {
-        assert!(false, "Failed to cast Chunk -> InitAck");
+        panic!("Failed to cast Chunk -> InitAck");
     }
 
     Ok(())
@@ -694,7 +694,7 @@ fn test_reconfig_chunk() -> Result<()> {
             "unexpected stream identifier"
         );
     } else {
-        assert!(false, "Failed to cast Chunk -> Reconfig");
+        panic!("Failed to cast Chunk -> Reconfig");
     }
 
     Ok(())
@@ -717,7 +717,7 @@ fn test_forward_tsn_chunk() -> Result<()> {
             c.new_cumulative_tsn
         );
     } else {
-        assert!(false, "Failed to cast Chunk -> Forward TSN");
+        panic!("Failed to cast Chunk -> Forward TSN");
     }
 
     Ok(())

--- a/src/chunk/chunk_test.rs
+++ b/src/chunk/chunk_test.rs
@@ -104,7 +104,6 @@ fn test_abort_chunk_many_error_causes() -> Result<()> {
 //chunk_error_test
 ///////////////////////////////////////////////////////////////////
 use super::chunk_error::*;
-use bytes::BufMut;
 use lazy_static::lazy_static;
 
 const CHUNK_FLAGS: u8 = 0x00;

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -22,7 +22,6 @@ use crate::error::{Error, Result};
 use chunk_header::*;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::marker::Sized;
 use std::{any::Any, fmt};
 
 pub(crate) trait Chunk: fmt::Display + fmt::Debug {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@ pub use crate::queue::reassembly_queue::{Chunk, Chunks};
 pub(crate) mod util;
 
 /// Whether an endpoint was the initiator of an association
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub enum Side {
     /// The initiator of an association
     #[default]
@@ -68,8 +67,6 @@ pub enum Side {
     /// The acceptor of an association
     Server = 1,
 }
-
-
 
 impl fmt::Display for Side {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,18 +60,16 @@ pub(crate) mod util;
 
 /// Whether an endpoint was the initiator of an association
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Default)]
 pub enum Side {
     /// The initiator of an association
+    #[default]
     Client = 0,
     /// The acceptor of an association
     Server = 1,
 }
 
-impl Default for Side {
-    fn default() -> Self {
-        Side::Client
-    }
-}
+
 
 impl fmt::Display for Side {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/param/param_chunk_list.rs
+++ b/src/param/param_chunk_list.rs
@@ -1,7 +1,7 @@
 use super::{param_header::*, param_type::*, *};
 use crate::chunk::chunk_type::*;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::BufMut;
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamChunkList {

--- a/src/param/param_forward_tsn_supported.rs
+++ b/src/param/param_forward_tsn_supported.rs
@@ -1,7 +1,5 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-
 /// At the initialization of the association, the sender of the INIT or
 /// INIT ACK chunk MAY include this OPTIONAL parameter to inform its peer
 /// that it is able to support the Forward TSN chunk

--- a/src/param/param_header.rs
+++ b/src/param/param_header.rs
@@ -1,7 +1,6 @@
 use super::{param_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
+use bytes::BufMut;
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamHeader {

--- a/src/param/param_heartbeat_info.rs
+++ b/src/param/param_heartbeat_info.rs
@@ -1,7 +1,5 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamHeartbeatInfo {
     pub(crate) heartbeat_information: Bytes,

--- a/src/param/param_outgoing_reset_request.rs
+++ b/src/param/param_outgoing_reset_request.rs
@@ -1,6 +1,6 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::BufMut;
 
 pub(crate) const PARAM_OUTGOING_RESET_REQUEST_STREAM_IDENTIFIERS_OFFSET: usize = 12;
 

--- a/src/param/param_random.rs
+++ b/src/param/param_random.rs
@@ -1,7 +1,5 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Bytes, BytesMut};
-
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamRandom {
     pub(crate) random_data: Bytes,

--- a/src/param/param_reconfig_response.rs
+++ b/src/param/param_reconfig_response.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
+#[derive(Default)]
 pub(crate) enum ReconfigResult {
     SuccessNop = 0,
     SuccessPerformed = 1,
@@ -13,14 +14,11 @@ pub(crate) enum ReconfigResult {
     ErrorRequestAlreadyInProgress = 4,
     ErrorBadSequenceNumber = 5,
     InProgress = 6,
+    #[default]
     Unknown,
 }
 
-impl Default for ReconfigResult {
-    fn default() -> Self {
-        ReconfigResult::Unknown
-    }
-}
+
 
 impl fmt::Display for ReconfigResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/param/param_reconfig_response.rs
+++ b/src/param/param_reconfig_response.rs
@@ -1,7 +1,6 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
+use bytes::BufMut;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
@@ -17,8 +16,6 @@ pub(crate) enum ReconfigResult {
     #[default]
     Unknown,
 }
-
-
 
 impl fmt::Display for ReconfigResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/param/param_requested_hmac_algorithm.rs
+++ b/src/param/param_requested_hmac_algorithm.rs
@@ -1,7 +1,6 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::fmt;
+use bytes::BufMut;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]

--- a/src/param/param_state_cookie.rs
+++ b/src/param/param_state_cookie.rs
@@ -1,8 +1,6 @@
 use super::{param_header::*, param_type::*, *};
 
-use bytes::{Bytes, BytesMut};
 use rand::Rng;
-use std::fmt;
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamStateCookie {

--- a/src/param/param_supported_extensions.rs
+++ b/src/param/param_supported_extensions.rs
@@ -1,7 +1,7 @@
 use super::{param_header::*, param_type::*, *};
 use crate::chunk::chunk_type::*;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::BufMut;
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct ParamSupportedExtensions {

--- a/src/param/param_test.rs
+++ b/src/param/param_test.rs
@@ -168,7 +168,6 @@ fn test_param_outgoing_reset_request_failure() -> Result<()> {
 //param_reconfig_response_test
 ///////////////////////////////////////////////////////////////////
 use super::param_reconfig_response::*;
-use bytes::Buf;
 
 static CHUNK_RECONFIG_RESPONCE: Bytes =
     Bytes::from_static(&[0x0, 0x10, 0x0, 0xc, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1]);

--- a/src/param/param_type.rs
+++ b/src/param/param_type.rs
@@ -61,8 +61,6 @@ pub(crate) enum ParamType {
     Unknown,
 }
 
-
-
 impl fmt::Display for ParamType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match *self {

--- a/src/param/param_type.rs
+++ b/src/param/param_type.rs
@@ -3,6 +3,7 @@ use std::fmt;
 /// paramType represents a SCTP INIT/INITACK parameter
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
+#[derive(Default)]
 pub(crate) enum ParamType {
     HeartbeatInfo = 1,
     /// Heartbeat Info [RFCRFC4960]
@@ -56,14 +57,11 @@ pub(crate) enum ParamType {
     /// Success Indication (0xC005) [RFCRFC5061]
     AdaptLayerInd = 49158,
     /// Adaptation Layer Indication (0xC006) [RFCRFC5061]
+    #[default]
     Unknown,
 }
 
-impl Default for ParamType {
-    fn default() -> Self {
-        ParamType::Unknown
-    }
-}
+
 
 impl fmt::Display for ParamType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/queue/pending_queue.rs
+++ b/src/queue/pending_queue.rs
@@ -34,19 +34,19 @@ impl PendingQueue {
     pub(crate) fn peek(&self) -> Option<&ChunkPayloadData> {
         if self.selected {
             if self.unordered_is_selected {
-                return self.unordered_queue.get(0);
+                return self.unordered_queue.front();
             } else {
-                return self.ordered_queue.get(0);
+                return self.ordered_queue.front();
             }
         }
 
-        let c = self.unordered_queue.get(0);
+        let c = self.unordered_queue.front();
 
         if c.is_some() {
             return c;
         }
 
-        self.ordered_queue.get(0)
+        self.ordered_queue.front()
     }
 
     pub(crate) fn pop(

--- a/src/queue/queue_test.rs
+++ b/src/queue/queue_test.rs
@@ -79,7 +79,7 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
     pq.push(make_payload(5, 0), 0);
     pq.push(make_payload(6, 0), 0);
 
-    let gab1 = vec![GapAckBlock { start: 1, end: 6 }];
+    let gab1 = [GapAckBlock { start: 1, end: 6 }];
     let gab2 = pq.get_gap_ack_blocks(0);
     assert!(!gab2.is_empty());
     assert_eq!(gab2.len(), 1);
@@ -90,7 +90,7 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
     pq.push(make_payload(8, 0), 0);
     pq.push(make_payload(9, 0), 0);
 
-    let gab1 = vec![
+    let gab1 = [
         GapAckBlock { start: 1, end: 6 },
         GapAckBlock { start: 8, end: 9 },
     ];
@@ -262,7 +262,7 @@ fn test_pending_base_queue_push_and_pop() -> Result<()> {
 fn test_pending_base_queue_out_of_bounce() -> Result<()> {
     let mut pq = PendingBaseQueue::new();
     assert!(pq.pop_front().is_none(), "should be none");
-    assert!(pq.get(0).is_none(), "should be none");
+    assert!(pq.front().is_none(), "should be none");
 
     pq.push_back(make_data_chunk(0, false, NO_FRAGMENT));
     assert!(pq.get(1).is_none(), "should be none");
@@ -471,7 +471,7 @@ fn test_reassembly_queue_ordered_fragments() -> Result<()> {
         assert_eq!(chunks.ppi, org_ppi, "should have valid ppi");
         assert_eq!(&buf[..n], b"ABCDEFG", "data should match");
     } else {
-        assert!(false);
+        panic!();
     }
 
     Ok(())
@@ -533,7 +533,7 @@ fn test_reassembly_queue_unordered_fragments() -> Result<()> {
         assert_eq!(chunks.ppi, org_ppi, "should have valid ppi");
         assert_eq!(&buf[..n], b"ABCDEFGH", "data should match");
     } else {
-        assert!(false);
+        panic!();
     }
 
     Ok(())
@@ -586,7 +586,7 @@ fn test_reassembly_queue_ordered_and_unordered_fragments() -> Result<()> {
         assert_eq!(chunks.ppi, org_ppi, "should have valid ppi");
         assert_eq!(&buf[..n], b"DEF", "data should match");
     } else {
-        assert!(false);
+        panic!();
     }
 
     // Next should read ordered chunks
@@ -597,7 +597,7 @@ fn test_reassembly_queue_ordered_and_unordered_fragments() -> Result<()> {
         assert_eq!(chunks.ppi, org_ppi, "should have valid ppi");
         assert_eq!(&buf[..n], b"ABC", "data should match");
     } else {
-        assert!(false);
+        panic!();
     }
 
     Ok(())
@@ -666,7 +666,7 @@ fn test_reassembly_queue_unordered_complete_skips_incomplete() -> Result<()> {
         assert_eq!(chunks.ppi, org_ppi, "should have valid ppi");
         assert_eq!(&buf[..n], b"GOOD", "data should match");
     } else {
-        assert!(false);
+        panic!();
     }
 
     Ok(())
@@ -801,7 +801,7 @@ fn test_reassembly_queue_detect_buffer_too_short() -> Result<()> {
         }
         assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
     } else {
-        assert!(false);
+        panic!();
     }
 
     Ok(())


### PR DESCRIPTION
Fixed clippys for rust stable 1.76

-  Dev clippys
-  Test clippys
-  Removed unused imports

test result: ok. 103 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.85s
