### PR TITLE
Don't log user initiated abort as err

### DIFF
--- a/src/association/mod.rs
+++ b/src/association/mod.rs
@@ -11,7 +11,7 @@ use crate::chunk::{
     chunk_reconfig::ChunkReconfig, chunk_selective_ack::ChunkSelectiveAck,
     chunk_shutdown::ChunkShutdown, chunk_shutdown_ack::ChunkShutdownAck,
     chunk_shutdown_complete::ChunkShutdownComplete, chunk_type::CT_FORWARD_TSN, Chunk,
-    ErrorCauseUnrecognizedChunkType,
+    ErrorCauseUnrecognizedChunkType, USER_INITIATED_ABORT,
 };
 use crate::config::{ServerConfig, TransportConfig, COMMON_HEADER_SIZE, DATA_CHUNK_HEADER_SIZE};
 use crate::error::{Error, Result};
@@ -829,6 +829,11 @@ impl Association {
         } else if let Some(c) = chunk_any.downcast_ref::<ChunkAbort>() {
             let mut err_str = String::new();
             for e in &c.error_causes {
+                if matches!(e.code, USER_INITIATED_ABORT) {
+                    debug!("User initiated abort received");
+                    let _ = self.close();
+                    return Ok(());
+                }
                 err_str += &format!("({})", e);
             }
             return Err(Error::ErrAbortChunk(err_str));


### PR DESCRIPTION
In some shutdown scenarios were we do sctp user initiated abort this generates Error in our log and we cannot turn it off.

Since the abort is intentional this PR, suggest to change this error message to debug instead.

Tested with our server and I verified that the change caused this line:

2024-04-28T03:06:35.556480Z ERROR sctp_proto::association: handle_inbound got err: abort chunk, with following errors: (User Initiated Abort)

to:

2024-04-28T03:48:57.762789Z DEBUG sctp_proto::association: User initiated abort received 

